### PR TITLE
Update alchemy gufe import

### DIFF
--- a/drugforge-alchemy/drugforge/alchemy/schema/_util.py
+++ b/drugforge-alchemy/drugforge/alchemy/schema/_util.py
@@ -1,6 +1,6 @@
 from collections import Counter
 from typing import TYPE_CHECKING
-from gufe.custom_json import JSONCodec
+from gufe.serialization.json import JSONCodec
 from alchemiscale import ScopedKey
 
 if TYPE_CHECKING:


### PR DESCRIPTION
A recent update to `gufe` changed where the `JSONCodec` class lives, update import to new location. Fixes #101.