### PR TITLE
enable CI to run on add-split-model branch

### DIFF
--- a/.github/workflows/alchemy.yaml
+++ b/.github/workflows/alchemy.yaml
@@ -8,6 +8,7 @@ on:
     branches:
       - "main"
       - "pydantic_2"
+      - "add-split-model"
   schedule:
     # Nightly tests run on main by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.

--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -8,6 +8,8 @@ on:
     branches:
       - "main"
       - "pydantic_2"
+      - "add-split-model"
+
   schedule:
     # Nightly tests run on main by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.

--- a/.github/workflows/data.yaml
+++ b/.github/workflows/data.yaml
@@ -8,6 +8,7 @@ on:
     branches:
       - "main"
       - "pydantic_2"
+      - "add-split-model"
   schedule:
     # Nightly tests run on main by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.

--- a/.github/workflows/dataviz.yaml
+++ b/.github/workflows/dataviz.yaml
@@ -8,6 +8,7 @@ on:
     branches:
       - "main"
       - "pydantic_2"
+      - "add-split-model"
   schedule:
     # Nightly tests run on main by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.

--- a/.github/workflows/docking.yaml
+++ b/.github/workflows/docking.yaml
@@ -8,6 +8,7 @@ on:
     branches:
       - "main"
       - "pydantic_2"
+      - "add-split-model"
   schedule:
     # Nightly tests run on main by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.

--- a/.github/workflows/ml.yaml
+++ b/.github/workflows/ml.yaml
@@ -8,6 +8,7 @@ on:
     branches:
       - "main"
       - "pydantic_2"
+      - "add-split-model"
   schedule:
     # Nightly tests run on main by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.

--- a/.github/workflows/modeling.yaml
+++ b/.github/workflows/modeling.yaml
@@ -8,6 +8,7 @@ on:
     branches:
       - "main"
       - "pydantic_2"
+      - "add-split-model"
   schedule:
     # Nightly tests run on main by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.

--- a/.github/workflows/simulation.yaml
+++ b/.github/workflows/simulation.yaml
@@ -8,6 +8,7 @@ on:
     branches:
       - "main"
       - "pydantic_2"
+      - "add-split-model"
   schedule:
     # Nightly tests run on main by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.

--- a/.github/workflows/spectrum.yaml
+++ b/.github/workflows/spectrum.yaml
@@ -8,6 +8,7 @@ on:
     branches:
       - "main"
       - "pydantic_2"
+      - "add-split-model"
   schedule:
     # Nightly tests run on main by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -8,6 +8,7 @@ on:
     branches:
       - "main"
       - "pydantic_2"
+      - "add-split-model"
   schedule:
     # Nightly tests run on main by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.


### PR DESCRIPTION
## Description
I'm pushing to add-split-model for revising for pydantic v2 updates, and thus need to enable CI to run on that branch. 

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/drugforge/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
