### PR TITLE
Spectrum test env fix. Pinning minimum openff toolkit

### DIFF
--- a/devtools/conda-envs/macos-latest/spectrum.yaml
+++ b/devtools/conda-envs/macos-latest/spectrum.yaml
@@ -33,6 +33,7 @@ dependencies:
   - mdanalysis
   - openeye-toolkits
   - openfe ~=1.0
+  - openff-toolkit-base>=0.17  # Added to patch openff-interchange 0.4.5_1 build deps error
   - openmm
   - openmmtools
   - openmmforcefields >= 0.13.0

--- a/devtools/conda-envs/ubuntu-latest/spectrum.yaml
+++ b/devtools/conda-envs/ubuntu-latest/spectrum.yaml
@@ -33,6 +33,7 @@ dependencies:
   - mdanalysis
   - openeye-toolkits
   - openfe ~=1.0
+  - openff-toolkit-base>=0.17  # Added to patch openff-interchange 0.4.5_1 build deps error
   - openmm
   - gufe >=1.0.0
   - pymol-open-source

--- a/drugforge-spectrum/drugforge/spectrum/tests/test_score.py
+++ b/drugforge-spectrum/drugforge/spectrum/tests/test_score.py
@@ -111,12 +111,12 @@ def test_vina_score(target_prepped_vina, ligand_prepped_vina):
 def test_minimize(protein_path, tmp_path):
     """Test minimization of protein PDB using OpenMM."""
     min_out = f"{tmp_path}/min_out.pdb"
-    minimize_structure(
-    pdb_complex = protein_path,
-    min_out = min_out,
-    out_dir = tmp_path,
-    md_platform = 'CPU',
-    comp_name = 'Mol',
-    target_name = 'SARS-CoV-2',)
+    min_out = minimize_structure(
+        pdb_complex=protein_path,
+        min_out=min_out,
+        out_dir=tmp_path,
+        md_platform='CPU',
+        comp_name='Mol',
+        target_name='SARS-CoV-2',)
 
     assert Path(min_out).exists()


### PR DESCRIPTION
## Description
There is a dependency issue within the `openff` ecosystem. Namely the `openff-interchange` 0.4.5 and build 0 has the wrong dependency for `openff-toolkit`, generating an `ImportError` that we are masking with the way we are running simulations with the `VanillaMDSimulator`.

This set of changes pin the `openff-toolkit-base` version ONLY for the `spectrum` CI, to circumvent this issues.

A real solution is for the `openff-interchange` package to restroactively patch the 0.4.5 packages to have the correct dependencies.

Solves #112

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [ ] Point 1 ...

## Questions
- [ ] Question 1 ..

## Status
- [x] Ready to go


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/drugforge/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
